### PR TITLE
Resolution switching

### DIFF
--- a/Video.js
+++ b/Video.js
@@ -421,7 +421,10 @@ Video.propTypes = {
     PropTypes.number,
     PropTypes.object
   ]),
-  maxResolution: PropTypes.number,
+  maxResolution: PropTypes.shape({
+    width: PropTypes.number,
+    height: PropTypes.number,
+  }),
   resolutionsMenu: PropTypes.shape({
     title: PropTypes.string,
     items: PropTypes.arrayOf(PropTypes.shape({

--- a/Video.js
+++ b/Video.js
@@ -421,7 +421,16 @@ Video.propTypes = {
     PropTypes.number,
     PropTypes.object
   ]),
+  maxResolution: PropTypes.number,
+  resolutionsMenu: PropTypes.shape({
+    title: PropTypes.string,
+    items: PropTypes.arrayOf(PropTypes.shape({
+      title: PropTypes.string,
+      value: PropTypes.number,
+    }))
+  }),
   fullscreen: PropTypes.bool,
+  onResolutionSelect: PropTypes.func,
   onVideoLoadStart: PropTypes.func,
   onVideoLoad: PropTypes.func,
   onVideoBuffer: PropTypes.func,

--- a/ios/Video/RCTVideo.h
+++ b/ios/Video/RCTVideo.h
@@ -20,6 +20,7 @@
 @interface RCTVideo : UIView <RCTVideoPlayerViewControllerDelegate, AVPictureInPictureControllerDelegate, AVAssetResourceLoaderDelegate,AVPlayerViewControllerDelegate>
 #endif
 
+@property (nonatomic, copy) RCTDirectEventBlock onResolutionSelect;
 @property (nonatomic, copy) RCTDirectEventBlock onVideoLoadStart;
 @property (nonatomic, copy) RCTDirectEventBlock onVideoLoad;
 @property (nonatomic, copy) RCTDirectEventBlock onVideoBuffer;

--- a/ios/Video/RCTVideo.m
+++ b/ios/Video/RCTVideo.m
@@ -69,6 +69,7 @@ static int const RCTVideoUnset = -1;
   NSURL *_videoURL;
   BOOL _requestingCertificate;
   BOOL _requestingCertificateErrored;
+  NSDictionary* _resolutionMenu;
 
   /* DRM */
   NSDictionary *_drm;
@@ -1268,6 +1269,25 @@ static int const RCTVideoUnset = -1;
   }
 }
 
+- (void)setMaxResolution:(NSDictionary *)maxResolution
+{
+    NSNumber *width = maxResolution[@"width"];
+    NSNumber *height = maxResolution[@"height"];
+    
+    if (@available(tvOS 11.0, *)) {
+        [self->_playerItem setPreferredMaximumResolution:CGSizeMake(width.floatValue, height.floatValue)];
+        DebugLog(@"Setting max resolution to: %f by %f", width.floatValue, height.floatValue);
+    } else {
+        DebugLog(@"can't perform: Setting max resolution to: %f by %f, tvos < 11", width.floatValue, height.floatValue);
+    }
+}
+
+- (void)setResolutionsMenu:(NSDictionary *)subMenu
+{
+    _resolutionMenu = subMenu;
+    // NOOP, we update ui once all meta data are ready, see: setPlayerUI method
+}
+
 - (void)setRate:(float)rate
 {
   _rate = rate;
@@ -1847,6 +1867,41 @@ static int const RCTVideoUnset = -1;
 
 
             self->_playerViewController.transportBarCustomMenuItems=customMenuItems;
+
+            // Adding Resolution Selection menu
+            if (@available(tvOS 15.0, *)) {
+                UIImage *resolutionSwitchIcon = [UIImage systemImageNamed:@"gear.circle"];
+                NSString * title = [_resolutionMenu valueForKey:@"title"];
+                NSArray * items = [_resolutionMenu valueForKey:@"items"];
+                
+                NSMutableArray * subMenuItems = [[NSMutableArray alloc] init];
+                
+                for (NSDictionary * item in items) {
+                    NSString * itemTitle = [item valueForKey:@"title"];
+                    NSString * itemValue = [item valueForKey:@"value"];
+
+                    UIAction * itemAction = [UIAction actionWithTitle:itemTitle image:nil identifier:nil handler:^(__kindof UIAction * _Nonnull action) {
+                        DebugLog(@"Pressing Resolution Selection %@", itemTitle);
+                        NSDictionary * args =  @{
+                            @"type": @"onResolutionSelected",
+                            @"value": itemValue,
+                        };
+                        self.onResolutionSelect(args);
+                    }];
+                    [subMenuItems addObject:itemAction];
+                }
+                
+                UIMenu * uiSubMenu = [UIMenu menuWithTitle:title image:resolutionSwitchIcon identifier:nil options:UIMenuOptionsSingleSelection children:subMenuItems];
+                NSArray * arr = [_playerViewController transportBarCustomMenuItems];
+                if(arr == nil ){
+                    arr = @[];
+                }
+                NSArray<__kindof UIMenuElement *> * menuItems = [arr arrayByAddingObject:uiSubMenu];
+                
+                self->_playerViewController.transportBarCustomMenuItems = menuItems;
+            } else {
+                // custom sub menus are not supported before tvOS15
+            }
         }
         NSString *title = [_playerMetaData objectForKey:@"title"];
         NSString *type = [_playerMetaData objectForKey:@"type"];

--- a/ios/Video/RCTVideoManager.m
+++ b/ios/Video/RCTVideoManager.m
@@ -45,6 +45,7 @@ RCT_EXPORT_VIEW_PROPERTY(playWhenInactive, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(pictureInPicture, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(ignoreSilentSwitch, NSString);
 RCT_EXPORT_VIEW_PROPERTY(rate, float);
+RCT_EXPORT_VIEW_PROPERTY(maxResolution, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(seek, NSDictionary);
 RCT_EXPORT_VIEW_PROPERTY(currentTime, float);
 RCT_EXPORT_VIEW_PROPERTY(fullscreen, BOOL);
@@ -54,7 +55,9 @@ RCT_EXPORT_VIEW_PROPERTY(filter, NSString);
 RCT_EXPORT_VIEW_PROPERTY(filterEnabled, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(progressUpdateInterval, float);
 RCT_EXPORT_VIEW_PROPERTY(restoreUserInterfaceForPIPStopCompletionHandler, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(resolutionsMenu, NSDictionary);
 /* Should support: onLoadStart, onLoad, and onError to stay consistent with Image */
+RCT_EXPORT_VIEW_PROPERTY(onResolutionSelect, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoadStart, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoLoad, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onVideoBuffer, RCTDirectEventBlock);


### PR DESCRIPTION
Adding the ability to set max resolution by setting width and height values 
also, bridging this to rn side with new 3 props
```js
 maxResolution: PropTypes.shape({
    width: PropTypes.number, // max width
    height: PropTypes.number, // max height
  }),
  resolutionsMenu: PropTypes.shape({ // this will build the resolution sub menu on the native av player controller 
    title: PropTypes.string,
    items: PropTypes.arrayOf(PropTypes.shape({
      title: PropTypes.string,
      value: PropTypes.number,
    }))
  }),
  onResolutionSelect: PropTypes.func, // callback block with the selected resolution
```


usage example:
```js
maxResolution={{
    width: 512,
    height: 288,
}}
resolutionsMenu={{
    title: "Resolutions",
    items: [
        {
            title: "Supreme Quality (4K)",
            value: "max"
        },
        {
            title: "High Quality",
            value: "high"
        },
        {
            title: "Medium Quality",
            value: "mid"
        },
        {
            title: "Low Quality",
            value: "low"
        },
        {
            title: "Auto",
            value: "auto"
        }
    ]
}}
onResolutionSelect={({nativeEvent})=>console.log("Got menu item pressed with", nativeEvent)}                          
```